### PR TITLE
added @username at the response text

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -198,7 +198,7 @@ class Dice:
             if len(self.result['visual']) > 275:
                 self.result['visual'] = self.result['visual'][0:275] + ' . . . )'
 
-            response = (curnt_input.user + ' rolled<b>' + self.label + '</b>:\r\n'        
+            response = ('@' + curnt_input.user + ' rolled<b>' + self.label + '</b>:\r\n'        
                 + self.result['visual'] + ' =\r\n<b>' + str(self.result['total']) + '</b>')
             error = ''
 


### PR DESCRIPTION
I added the @ on the username when the bot rolls the dice for a user. Example @username instead of just username, so another user can click the username and send private message or more.